### PR TITLE
Add utf-16 code unit length checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssb-legacy-msg-data"
+version = "0.1.2"
+source = "git+https://github.com/mycognosist/legacy-msg-data#805a958b35626f1aba63d2610a674fc92d1a3455"
+dependencies = [
+ "base64 0.10.1",
+ "encode_unicode",
+ "indexmap",
+ "ryu-ecmascript",
+ "serde",
+ "serde_derive",
+ "strtod2",
+]
+
+[[package]]
 name = "ssb-multiformats"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,13 +1858,13 @@ dependencies = [
 [[package]]
 name = "ssb-validate"
 version = "1.0.1"
-source = "git+https://github.com/mycognosist/ssb-validate?branch=out_of_order#f6abb977678a308735c2331609403527d2a9f6ea"
+source = "git+https://github.com/mycognosist/ssb-validate#ee7f2a9c762856fb0bddd8e73affc46efd821428"
 dependencies = [
  "rayon",
  "serde",
  "sha2 0.8.2",
  "snafu",
- "ssb-legacy-msg-data",
+ "ssb-legacy-msg-data 0.1.2 (git+https://github.com/mycognosist/legacy-msg-data)",
  "ssb-multiformats",
 ]
 
@@ -1881,7 +1895,7 @@ dependencies = [
  "serde_json",
  "sha2 0.8.2",
  "snafu",
- "ssb-legacy-msg-data",
+ "ssb-legacy-msg-data 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,15 @@
 [package]
 name = "ssb-validate2-rsjs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
 node-bindgen = { version = "4.0" }
-#ssb-validate = "1.0.1"
-ssb-validate = { git = "https://github.com/mycognosist/ssb-validate", branch = "out_of_order" }
+ssb-validate = { git = "https://github.com/mycognosist/ssb-validate" }
 ssb-verify-signatures = "1.0.0"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cryptographic validation of Scuttlebutt messages in the form of Rust bindings for Node.js.
 
-Perform batch verification and validation of SSB messages using [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) and [ssb-validate](https://crates.io/crates/ssb-validate) from the [Sunrise Choir](https://github.com/sunrise-choir).
+Perform batch verification and validation of SSB messages using [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) and [ssb-validate](https://github.com/mycognosist/ssb-validate) from the [Sunrise Choir](https://github.com/sunrise-choir).
 
 The [node-bindgen](https://github.com/infinyon/node-bindgen) crate is currently used to generate the bindings from Rust code.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,11 @@ fn verify_messages(array: Vec<String>) -> Result<bool, NjError> {
 fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Result<bool, NjError> {
     let mut msgs = Vec::new();
     for msg in array {
+        // ensure the encoded message is less than 8192 code unit (utf-16)
+        if msg.encode_utf16().count() > 8192 {
+            let err_msg = format!("found invalid message: encoded message must not be larger than 8192 code units (utf-16): {}", msg);
+            return Err(NjError::Other(err_msg));
+        }
         let msg_bytes = msg.into_bytes();
         msgs.push(msg_bytes)
     }
@@ -90,6 +95,10 @@ fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Res
 fn verify_validate_out_of_order_messages(array: Vec<String>) -> Result<bool, NjError> {
     let mut msgs = Vec::new();
     for msg in array {
+        if msg.encode_utf16().count() > 8192 {
+            let err_msg = format!("found invalid message: encoded message must not be larger than 8192 code units (utf-16): {}", msg);
+            return Err(NjError::Other(err_msg));
+        }
         let msg_bytes = msg.into_bytes();
         msgs.push(msg_bytes)
     }


### PR DESCRIPTION
Perform a `utf-16` length check (total code units) on the JSON encoded string for each message. A message must have fewer than 8192 `utf-16` code units in order to pass the check. This check has been composed to conform to the corresponding JavaScript evaluation in ssb-validate ([L110 of index.js](https://github.com/ssb-js/ssb-validate/blob/889434a16357857bbfff95f4da14e66fef7175b1/index.js#L110)).

The length check has been added for `validateBatch()` and `validateOOOBatch()`. It has been left out of `verifySignatures()` since this method is intended to perform signature verification only.

Other housekeeping in this PR:

 - Bump the version number for this crate
 - Update the README to point to the @mycognosist fork of [ssb-validate](https://github.com/mycognosist/ssb-validate) (stricter validation criteria)
 - Update manifest to use main branch of ssb-validate as dependency