### PR TITLE
Add method for multi-author out-of-order validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -56,16 +56,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb9af4888a70ad78ecb5efcb0ba95d66a3cf54a88b62ae81559954c7588c7a2"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -98,8 +98,8 @@ dependencies = [
  "once_cell",
  "parking",
  "polling",
+ "slab",
  "socket2",
- "vec-arena",
  "waker-fn",
  "winapi",
 ]
@@ -362,10 +362,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpuid-bool"
@@ -396,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -409,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if",
@@ -490,9 +493,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
 dependencies = [
  "signature",
 ]
@@ -518,7 +521,7 @@ dependencies = [
  "curve25519-dalek 3.1.0",
  "ed25519",
  "rand 0.7.3",
- "sha2 0.9.3",
+ "sha2 0.9.4",
  "zeroize",
 ]
 
@@ -563,9 +566,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -753,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes",
  "fnv",
@@ -808,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -825,15 +828,15 @@ checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -965,9 +968,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "log"
@@ -996,9 +999,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -1182,9 +1185,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1202,9 +1205,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -1282,7 +1285,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
 dependencies = [
- "cpuid-bool 0.2.0",
+ "cpuid-bool",
  "universal-hash",
 ]
 
@@ -1532,18 +1535,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1562,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1727,13 +1730,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpuid-bool 0.1.2",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -1755,9 +1758,9 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -1807,7 +1810,7 @@ dependencies = [
  "ed25519-dalek 1.0.1",
  "hmac",
  "rand 0.7.3",
- "sha2 0.9.3",
+ "sha2 0.9.4",
  "subtle",
  "x25519-dalek",
  "xsalsa20poly1305",
@@ -1833,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "ssb-legacy-msg-data"
 version = "0.1.2"
-source = "git+https://github.com/mycognosist/legacy-msg-data#805a958b35626f1aba63d2610a674fc92d1a3455"
+source = "git+https://github.com/mycognosist/legacy-msg-data#366306a58c751d1bdf13419313796d4e3d92cae2"
 dependencies = [
  "base64 0.10.1",
  "encode_unicode",
@@ -1857,10 +1860,12 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate"
-version = "1.0.1"
-source = "git+https://github.com/mycognosist/ssb-validate#ee7f2a9c762856fb0bddd8e73affc46efd821428"
+version = "1.2.0"
+source = "git+https://github.com/mycognosist/ssb-validate#e4e0837f8aeb8289a2b21b05695b6beb9b6cc724"
 dependencies = [
+ "lazy_static",
  "rayon",
+ "regex",
  "serde",
  "sha2 0.8.2",
  "snafu",
@@ -1870,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate2-rsjs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "node-bindgen",
  "ssb-validate",
@@ -1912,9 +1917,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2038,9 +2043,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2061,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -2091,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2143,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
@@ -2159,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2183,12 +2188,6 @@ name = "vcpkg"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
-
-[[package]]
-name = "vec-arena"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b2f665b594b07095e3ac3f718e13c2197143416fae4c5706cffb7b1af8d7f1"
 
 [[package]]
 name = "version_check"
@@ -2378,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9c39e6d503229ffa00cc2954af4a751e6bbedf2a2c18e856eb3ece93d32495"
+checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ validate.validateBatch(msgs, previous);
 
 // Validate an array of out-of-order messages by a single author
 validate.validateOOOBatch(msgs);
+
+// Validate an array of out-of-order messages by multiple authors
+validate.validateMultiAuthorBatch(msgs);
 ```
 
 See `test/test.js` in this repo for in-context example usage (uses [ssb-fixtures](https://github.com/ssb-ngi-pointer/ssb-fixtures) and [jitdb](https://github.com/ssb-ngi-pointer/jitdb)).
@@ -51,11 +54,13 @@ The `msgs` argument must always be in the form of an array of message objects.
 
 The `previous` argument for `validateBatch()` is optional. Calling the function without `previous` is the equivalent of passing `previous` as `null`.
 
-All three functions (`verifySignatures()`, `validateBatch()` and `validateOOOBatch()`) return `true` on success. In the case of a failure in verification or validation, these functions will return immediately with detailed information in the error message (currently includes the reason for failure and the full message which caused the failure).
+All four functions (`verifySignatures()`, `validateBatch()`, `validateOOOBatch()` and `validateMultiAuthorBatch()`) return `true` on success. In the case of a failure in verification or validation, these functions will return immediately with detailed information in the error message (currently includes the reason for failure and the full message which caused the failure).
 
-Note that `validateBatch()` and `validateOOOBatch()` perform signature verification _and_ full message validation.
+Note that `validateBatch()`, `validateOOOBatch()` and `validateMultiAuthorBatch()` perform signature verification _and_ full message validation.
 
 The `validateOOOBatch()` function does not perform checks for ascending sequence number (ie. if `sequence` of the current message equals `sequence` of `previous` plus one), nor does it validate the hash of the `previous` message against the value stored in `previous` of the current message. However, validation of the `author` field is performed (ie. `author` of `previous` message must match the `author` of the current message).
+
+The `validateMultiAuthorBatch()` function does not perform any checks of the `previous` message.
 
 ### Error Examples
 
@@ -179,9 +184,10 @@ After performing build instructions (see above):
 cd ssb-validate2-rsjs
 # Run benchmarks
 node test/perf
+node test/multiAuthorPerf
 ```
 
-The default values for the performance benchmarks are 100 messages from 1 author, for a total of 10 iterations. These value constants can be changed in `test/perf.js`.
+The default values for the performance benchmarks (`test/perf.js`) are 100 messages from 1 author, for a total of 10 iterations. These value constants can be changed in `test/perf.js`. Performance benchmarks for the multi-author method default to 100 messages from 5 authors, for a total of 10 iterations (`test/multiAuthorPerf.js`).
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,15 @@ const validateOOOBatch = (msgs) => {
   return v.validateOOOBatch(jsonMsgs);
 };
 
+const validateMultiAuthorBatch = (msgs) => {
+  if (!Array.isArray(msgs)) throw new Error('input must be an array of message objects')
+  const jsonMsgs = msgs.map((msg) => {
+    return JSON.stringify(msg, null, 2);
+  });
+  return v.validateMultiAuthorBatch(jsonMsgs);
+};
+
 module.exports.verifySignatures = verifySignatures;
 module.exports.validateBatch = validateBatch;
 module.exports.validateOOOBatch = validateOOOBatch;
+module.exports.validateMultiAuthorBatch = validateMultiAuthorBatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ fn verify_messages(array: Vec<String>) -> Result<bool, NjError> {
     }
 }
 
-/// Verify signatures and perform validation for an array of messages.
+/// Verify signatures and perform validation for an array of ordered messages by a single author.
 ///
 /// Takes an array of messages as the first argument and an optional previous message as the second
 /// argument. The previous message argument is expected when the array of messages does not start
@@ -53,10 +53,7 @@ fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Res
         msgs.push(msg_bytes)
     }
 
-    let previous_msg = match previous {
-        Some(msg) => Some(msg.into_bytes()),
-        None => None,
-    };
+    let previous_msg = previous.map(|msg| msg.into_bytes());
 
     // attempt batch verficiation and match on error to find invalid message
     match par_verify_messages(&msgs, None) {
@@ -87,6 +84,11 @@ fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Res
     }
 }
 
+/// Verify signatures and perform validation for an array of out-of-order messages by a single
+/// author.
+///
+/// Takes an array of messages as the only argument. If verification or validation fails, the
+/// cause of the error is returned along with the offending message.
 #[node_bindgen(name = "validateOOOBatch")]
 fn verify_validate_out_of_order_messages(array: Vec<String>) -> Result<bool, NjError> {
     let mut msgs = Vec::new();
@@ -124,6 +126,11 @@ fn verify_validate_out_of_order_messages(array: Vec<String>) -> Result<bool, NjE
     }
 }
 
+/// Verify signatures and perform validation for an array of out-of-order messages by multiple
+/// authors.
+///
+/// Takes an array of messages as the only argument. If verification or validation fails, the
+/// cause of the error is returned along with the offending message.
 #[node_bindgen(name = "validateMultiAuthorBatch")]
 fn verify_validate_multi_author_messages(array: Vec<String>) -> Result<bool, NjError> {
     let mut msgs = Vec::new();

--- a/test/multiAuthorPerf.js
+++ b/test/multiAuthorPerf.js
@@ -1,0 +1,131 @@
+const validate = require("../.");
+const legacyValidate = require("ssb-validate");
+const test = require("tape");
+const fs = require("fs");
+const path = require("path");
+const Log = require("async-append-only-log");
+const generateFixture = require("ssb-fixtures");
+const rimraf = require("rimraf");
+const mkdirp = require("mkdirp");
+const JITDB = require("jitdb");
+const {
+  query,
+  fromDB,
+  where,
+  equal,
+  slowEqual,
+  toCallback,
+} = require("jitdb/operators");
+const seekType = require("jitdb/test/helpers");
+const copy = require("jitdb/copy-json-to-bipf-async");
+
+// define directory and paths
+const dir = "/tmp/validate-benchmark";
+const oldLogPath = path.join(dir, "flume", "log.offset");
+const newLogPath = path.join(dir, "flume", "log.bipf");
+const indexesDir = path.join(dir, "indexes");
+
+// generate fixture
+rimraf.sync(dir);
+mkdirp.sync(dir);
+
+const SEED = "sloop";
+const MESSAGES = 100;
+const AUTHORS = 5;
+// run each test x times
+const ITERATIONS = 10;
+
+test("generate fixture with flumelog-offset", (t) => {
+  generateFixture({
+    outputDir: dir,
+    seed: SEED,
+    messages: MESSAGES,
+    authors: AUTHORS,
+    slim: true,
+  }).then(() => {
+    t.true(fs.existsSync(oldLogPath), "log.offset was created");
+    t.end();
+  });
+});
+
+test("move flumelog-offset to async-log", (t) => {
+  copy(oldLogPath, newLogPath, (err) => {
+    if (err) t.fail(err);
+    setTimeout(() => {
+      t.true(fs.existsSync(newLogPath), "log.bipf was created");
+      t.end();
+    }, 4000);
+  });
+});
+
+let raf;
+let db;
+
+test("core indexes", (t) => {
+  const start = Date.now();
+  raf = Log(newLogPath, { blockSize: 64 * 1024 });
+  rimraf.sync(indexesDir);
+  db = JITDB(raf, indexesDir);
+  db.onReady(() => {
+    const duration = Date.now() - start;
+    t.pass(`duration: ${duration}ms`);
+    t.end();
+  });
+});
+
+// batch verification and validation for an array of multi-author out-of-order messages
+test("validateMultiAuthorBatch", (t) => {
+  db.onReady(() => {
+    query(
+      fromDB(db),
+      toCallback((err, msgs) => {
+        if (err) t.fail(err);
+        var i;
+        var totalDuration = 0;
+        for (i = 0; i < ITERATIONS; i++) {
+          const start = Date.now();
+          // shuffle array of msgs to generate out-of-order state
+          msgs.sort(() => Math.random() - 0.5);
+          validate.validateMultiAuthorBatch(msgs);
+          const duration = Date.now() - start;
+          totalDuration += duration;
+          t.pass(`validated ${MESSAGES} messages in ${duration} ms`);
+        }
+        avgDuration = totalDuration / ITERATIONS;
+        console.log(`average duration: ${avgDuration} ms`);
+        t.end();
+      })
+    );
+  });
+});
+
+test("appendKVT (legacy validation)", (t) => {
+  db.onReady(() => {
+    query(
+      fromDB(db),
+      toCallback((err, msgs) => {
+        if (err) t.fail(err);
+        var i;
+        var totalDuration = 0;
+        for (i = 0; i < ITERATIONS; i++) {
+          var hmac_key = null;
+          var state = legacyValidate.initial();
+          const start = Date.now();
+          msgs.forEach(function (msg) {
+            try {
+              state = legacyValidate.appendKVT(state, hmac_key, msg);
+            } catch (err) {
+              console.log(err);
+            }
+          });
+          const duration = Date.now() - start;
+          totalDuration += duration;
+          t.pass(`validated ${MESSAGES} messages in ${duration} ms`);
+        }
+        avgDuration = totalDuration / ITERATIONS;
+        console.log(`average duration: ${avgDuration} ms`);
+        t.end();
+      })
+    );
+  });
+});

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -1,0 +1,86 @@
+const validate = require("../.");
+const test = require("tape");
+const fs = require("fs");
+const path = require("path");
+const Log = require("async-append-only-log");
+const generateFixture = require("ssb-fixtures");
+const rimraf = require("rimraf");
+const mkdirp = require("mkdirp");
+const JITDB = require("jitdb");
+const {
+  query,
+  fromDB,
+  where,
+  equal,
+  slowEqual,
+  toCallback,
+} = require("jitdb/operators");
+const seekType = require("jitdb/test/helpers");
+const copy = require("jitdb/copy-json-to-bipf-async");
+
+// define directory and paths
+const dir = "/tmp/validate-benchmark";
+const oldLogPath = path.join(dir, "flume", "log.offset");
+const newLogPath = path.join(dir, "flume", "log.bipf");
+const indexesDir = path.join(dir, "indexes");
+
+// generate fixture
+rimraf.sync(dir);
+mkdirp.sync(dir);
+
+const SEED = "sloop";
+const MESSAGES = 10;
+const AUTHORS = 22;
+
+test("generate fixture with flumelog-offset", (t) => {
+  generateFixture({
+    outputDir: dir,
+    seed: SEED,
+    messages: MESSAGES,
+    authors: AUTHORS,
+    slim: true,
+  }).then(() => {
+    t.true(fs.existsSync(oldLogPath), "log.offset was created");
+    t.end();
+  });
+});
+
+test("move flumelog-offset to async-log", (t) => {
+  copy(oldLogPath, newLogPath, (err) => {
+    if (err) t.fail(err);
+    setTimeout(() => {
+      t.true(fs.existsSync(newLogPath), "log.bipf was created");
+      t.end();
+    }, 4000);
+  });
+});
+
+let raf;
+let db;
+
+test("core indexes", (t) => {
+  raf = Log(newLogPath, { blockSize: 64 * 1024 });
+  rimraf.sync(indexesDir);
+  db = JITDB(raf, indexesDir);
+  db.onReady(() => {
+    t.pass(`database ready`);
+    t.end();
+  });
+});
+
+test("batch validation of out-of-order multi-author messages", (t) => {
+  db.onReady(() => {
+    query(
+      fromDB(db),
+      toCallback((err, msgs) => {
+        if (err) t.fail(err);
+        // shuffle the messages (generate out-of-order state)
+        msgs.sort(() => Math.random() - 0.5);
+        // attempt validation of all messages
+        t.true(validate.validateMultiAuthorBatch(msgs), "success");
+        t.pass(`validated ${MESSAGES} messages`);
+        t.end();
+      })
+    );
+  });
+});

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -30,7 +30,7 @@ mkdirp.sync(dir);
 
 const SEED = "sloop";
 const MESSAGES = 10;
-const AUTHORS = 22;
+const AUTHORS = 2;
 
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({

--- a/test/perf.js
+++ b/test/perf.js
@@ -121,6 +121,7 @@ test("validateBatch", (t) => {
     );
   });
 });
+
 // batch verification and validation for an array of out-of-order messages
 test("validateOOOBatch", (t) => {
   db.onReady(() => {
@@ -146,6 +147,7 @@ test("validateOOOBatch", (t) => {
     );
   });
 });
+
 test("appendKVT (legacy validation)", (t) => {
   db.onReady(() => {
     query(

--- a/test/test.js
+++ b/test/test.js
@@ -176,7 +176,7 @@ test("batch validation of partial feed (previous seq > 1)", (t) => {
       toCallback((err, msgs) => {
         if (err) t.fail(err);
         // skip first msg in the array
-	first = msgs.shift();
+        first = msgs.shift();
         // shift second msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages


### PR DESCRIPTION

Adds support for validating an array of out-of-order messages by multiple authors. This has been made possible by the addition of multi-author support to `ssb-validate` (https://github.com/mycognosist/ssb-validate/pull/13).

**Major changes**

 - Add batch verification and validation for an array of out-of-order messages by multiple authors
   - `validateMultiAuthorBatch(msgs)`
 - Add test and perf for multiAuthor (created as separate tests because of single versus multi-author scenario)
 - Update README for multiAuthor
 - Remove the `msg.value` length check (this check is performed in `ssb-validate-rs`)
 
**Minor changes**

 - Update doc comments for all methods
 - Run linter
 - Refactor `previous_msg` assignment to avoid manual implementation of `Option` (use `map` instead)