### PR TITLE
Add unique db directory per test batch

### DIFF
--- a/test/multiAuthorPerf.js
+++ b/test/multiAuthorPerf.js
@@ -20,7 +20,7 @@ const seekType = require("jitdb/test/helpers");
 const copy = require("jitdb/copy-json-to-bipf-async");
 
 // define directory and paths
-const dir = "/tmp/validate-benchmark";
+const dir = "/tmp/validate-multi-benchmark";
 const oldLogPath = path.join(dir, "flume", "log.offset");
 const newLogPath = path.join(dir, "flume", "log.bipf");
 const indexesDir = path.join(dir, "indexes");

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -19,7 +19,7 @@ const seekType = require("jitdb/test/helpers");
 const copy = require("jitdb/copy-json-to-bipf-async");
 
 // define directory and paths
-const dir = "/tmp/validate-benchmark";
+const dir = "/tmp/validate-multi-test";
 const oldLogPath = path.join(dir, "flume", "log.offset");
 const newLogPath = path.join(dir, "flume", "log.bipf");
 const indexesDir = path.join(dir, "indexes");

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ const seekType = require("jitdb/test/helpers");
 const copy = require("jitdb/copy-json-to-bipf-async");
 
 // define directory and paths
-const dir = "/tmp/validate-benchmark";
+const dir = "/tmp/validate-test";
 const oldLogPath = path.join(dir, "flume", "log.offset");
 const newLogPath = path.join(dir, "flume", "log.bipf");
 const indexesDir = path.join(dir, "indexes");


### PR DESCRIPTION
Fixes the test error when running `npm test` by using a unique temporary fixture directory for each test suite.