### PR TITLE
Return null (success) or string (error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ See `test/test.js` in this repo for in-context example usage (uses [ssb-fixtures
 
 ## Behaviour
 
+**Arguments**
+
 The `msg` and `previous` arguments must always be in the form of message objects.
 
 The `msgs` argument must always be in the form of an array of message objects.
 
 The `previous` argument for `validateSingle()` and `validateBatch()` is optional. Calling these functions without `previous` is the equivalent of passing `previous` as `null`.
 
-All five functions (`verifySignatures()`, `validateSingle()`, `validateBatch()`, `validateOOOBatch()` and `validateMultiAuthorBatch()`) return `true` on success. In the case of a failure in verification or validation, these functions will return immediately with detailed information in the error message (currently includes the reason for failure and the full message which caused the failure).
+**Return Expressions**
+
+All five functions (`verifySignatures()`, `validateSingle()`, `validateBatch()`, `validateOOOBatch()` and `validateMultiAuthorBatch()`) return `null` on success. In the case of a failure in verification or validation, these functions will return immediately with detailed information in the error message (currently includes the reason for failure and the full message which caused the failure). The error message is returned as a `string` type.
+
+**Validation Checks**
 
 Note that `validateSingle()`, `validateBatch()`, `validateOOOBatch()` and `validateMultiAuthorBatch()` perform signature verification _and_ full message validation.
 
@@ -78,15 +84,14 @@ Passing an incorrect type:
 ```javascript
 const v = require('ssb-validate2-rsjs');
 
-msgs = "this is a string"
+msgs = "this is a string";
 
-try {
-  v.verifySignatures(msgs)
-} catch (err) {
-  console.log(err.message)
+let err = v.verifySignatures(msgs);
+if (err) {
+  console.log(err)
 }
 
-// input must be an array of message objects
+// 'input must be an array of message objects'
 ```
 
 Failing signature verification:
@@ -113,30 +118,29 @@ msg = {
 
 msgs = [msg]
 
-try {
-  v.verifySignatures(msgs)
-} catch (err) {
-  console.log(err.message)
+let err = v.verifySignatures(msgs);
+if (err) {
+  console.log(err)
 }
 
-//found invalid message: Signature was invalid: {
-//  "key": "%kmXb3MXtBJaNugcEL/Q7G40DgcAkMNTj3yhmxKHjfCM=.sha256",
-//  "value": {
-//    "previous": "%IIjwbJbV3WBE/SBLnXEv5XM3Pr+PnMkrAJ8F+7TsUVQ=.sha256",
-//    "author": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",
-//    "sequence": 9,
-//    "timestamp": 1470187438539,
-//    "hash": "sha256",
-//    "content": {
-//      "type": "contact",
-//      "contact": "@ye+QM09iPcDJD6YvQYjoQc7sLF/IFhmNbEqgdzQo3lQ=.ed25519",
-//      "following": true,
-//      "blocking": false
-//    },
-//    "signature": "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519"
-//  },
-//  "timestamp": 1571140551543
-//}
+//'found invalid message: Signature was invalid: {\n' +
+//  '  "key": "%kmXb3MXtBJaNugcEL/Q7G40DgcAkMNTj3yhmxKHjfCM=.sha256",\n' +
+//  '  "value": {\n' +
+//  '    "previous": "%IIjwbJbV3WBE/SBLnXEv5XM3Pr+PnMkrAJ8F+7TsUVQ=.sha256",\n' +
+//  '    "author": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",\n' +
+//  '    "sequence": 9,\n' +
+//  '    "timestamp": 1470187438539,\n' +
+//  '    "hash": "sha256",\n' +
+//  '    "content": {\n' +
+//  '      "type": "contact",\n' +
+//  '      "contact": "@ye+QM09iPcDJD6YvQYjoQc7sLF/IFhmNbEqgdzQo3lQ=.ed25519",\n' +
+//  '      "following": true,\n' +
+//  '      "blocking": false\n' +
+//  '    },\n' +
+//  '    "signature": "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519"\n' +
+//  '  },\n' +
+//  '  "timestamp": 1571140551543\n' +
+//  '}'
 ```
 
 Failing validation due to incorrect sequence number:
@@ -161,28 +165,27 @@ msg = {
 
 msgs = [msg]
 
-try {
-  v.validateBatch(msgs)
-} catch (err) {
-  console.log(err.message)
+let err = v.validateBatch(msgs);
+if (err) {
+  console.log(err)
 }
 
-// found invalid message: The first message of a feed must have seq of 1: {
-//  "key": "%lYAK7Lfigw00zMt/UtVg5Ol9XdR4BHWUCxq4r2Ops90=.sha256",
-//  "value": {
-//    "previous": "%yV9QaYDbkEHl4W8S8hVf/3TUuvs0JUrOP945jLLK/2c=.sha256",
-//    "author": "@vt8uK0++cpFioCCBeB3p3jdx4RIdQYJOL/imN1Hv0Wk=.ed25519",
-//    "sequence": 36,
-//    "timestamp": 1445502075082,
-//    "hash": "sha256",
-//    "content": {
-//      "type": "post",
-//      "text": "Web frameworks.\n\n    Much industrial production in the late nineteenth century depended on skilled workers, whose knowledge of the production process often far exceeded their employers’; Taylor saw that this gave laborers a tremendous advantage over their employer in the struggle over the pace of work.\n\n    Not only could capitalists not legislate techniques they were ignorant of, but they were also in no position to judge when workers told them the process simply couldn’t be driven any faster. Work had to be redesigned so that employers did not depend on their employees for knowledge of the production process.\n\nhttps://www.jacobinmag.com/2015/04/braverman-gramsci-marx-technology/"
-//    },
-//    "signature": "FbDXlQtC2FQukU8svM5dOALN6QpxFhUHZaC7jTSXdOH7yqDfUlaj8q97YLdo5YqknZ71b0Y59hlQkmfkbtv5DA==.sig.ed25519"
-//  },
-//  "timestamp": 1571140555382.0059
-//}
+//'found invalid message: The first message of a feed must have seq of 1: {\n' +
+//  '  "key": "%lYAK7Lfigw00zMt/UtVg5Ol9XdR4BHWUCxq4r2Ops90=.sha256",\n' +
+//  '  "value": {\n' +
+//  '    "previous": "%yV9QaYDbkEHl4W8S8hVf/3TUuvs0JUrOP945jLLK/2c=.sha256",\n' +
+//  '    "author": "@vt8uK0++cpFioCCBeB3p3jdx4RIdQYJOL/imN1Hv0Wk=.ed25519",\n' +
+//  '    "sequence": 36,\n' +
+//  '    "timestamp": 1445502075082,\n' +
+//  '    "hash": "sha256",\n' +
+//  '    "content": {\n' +
+//  '      "type": "post",\n' +
+//  '      "text": "Web frameworks.\\n\\n    Much industrial production in the late nineteenth century depended on skilled workers, whose knowledge of the production process often far exceeded their employers’; Taylor saw that this gave laborers a tremendous advantage over their employer in the struggle over the pace of work.\\n\\n    Not only could capitalists not legislate techniques they were ignorant of, but they were also in no position to judge when workers told them the process simply couldn’t be driven any faster. Work had to be redesigned so that employers did not depend on their employees for knowledge of the production process.\\n\\nhttps://www.jacobinmag.com/2015/04/braverman-gramsci-marx-technology/"\n' +
+//  '    },\n' +
+//  '    "signature": "FbDXlQtC2FQukU8svM5dOALN6QpxFhUHZaC7jTSXdOH7yqDfUlaj8q97YLdo5YqknZ71b0Y59hlQkmfkbtv5DA==.sig.ed25519"\n' +
+//  '  },\n' +
+//  '  "timestamp": 1571140555382.0059\n' +
+//  '}'
 ```
 
 ## Performance Benchmarks

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const v = require("./dist/index.node");
 
 const verifySignatures = (msgs) => {
-  if (!Array.isArray(msgs)) throw new Error('input must be an array of message objects')
+  if (!Array.isArray(msgs)) return ('input must be an array of message objects')
   const jsonMsgs = msgs.map((msg) => {
     return JSON.stringify(msg, null, 2);
   });
@@ -18,7 +18,7 @@ const validateSingle = (msg, previous) => {
 }
 
 const validateBatch = (msgs, previous) => {
-  if (!Array.isArray(msgs)) throw new Error('input must be an array of message objects')
+  if (!Array.isArray(msgs)) return ('input must be an array of message objects')
   const jsonMsgs = msgs.map((msg) => {
     return JSON.stringify(msg, null, 2);
   });
@@ -30,7 +30,7 @@ const validateBatch = (msgs, previous) => {
 };
 
 const validateOOOBatch = (msgs) => {
-  if (!Array.isArray(msgs)) throw new Error('input must be an array of message objects')
+  if (!Array.isArray(msgs)) return ('input must be an array of message objects')
   const jsonMsgs = msgs.map((msg) => {
     return JSON.stringify(msg, null, 2);
   });

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -77,7 +77,7 @@ test("batch validation of out-of-order multi-author messages", (t) => {
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt validation of all messages
-        t.true(validate.validateMultiAuthorBatch(msgs), "success");
+        t.equal(validate.validateMultiAuthorBatch(msgs), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })

--- a/test/test.js
+++ b/test/test.js
@@ -95,7 +95,7 @@ test("batch verification of message signatures", (t) => {
       toCallback((err, msgs) => {
         if (err) t.fail(err);
         // attempt verification of all messages
-        t.true(validate.verifySignatures(msgs), "success");
+        t.equal(validate.verifySignatures(msgs), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -112,7 +112,7 @@ test("batch verification of out-of-order message signatures", (t) => {
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt verification of all messages
-        t.true(validate.verifySignatures(msgs), "success");
+        t.equal(validate.verifySignatures(msgs), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -122,7 +122,7 @@ test("batch verification of out-of-order message signatures", (t) => {
 
 test("verification of single message signature (valid)", (t) => {
   let msgs = [validMsg];
-  t.true(validate.verifySignatures(msgs), "success");
+  t.equal(validate.verifySignatures(msgs), null, "success");
   t.pass(`validated ${MESSAGES} messages`);
   t.end();
 });
@@ -131,17 +131,12 @@ test("verification of single message signature (invalid)", (t) => {
   let invalidMsg = validMsg;
   invalidMsg.value.content.following = false;
   let msgs = [invalidMsg];
-  try {
-    validate.verifySignatures(msgs);
-    t.fail("should have thrown");
-  } catch (err) {
-    t.match(
-      err.message,
-      /Signature was invalid/,
-      "found invalid message: Signature was invalid"
-    );
-    t.end();
-  }
+  t.match(
+    validate.verifySignatures(msgs),
+    /Signature was invalid/,
+    "found invalid message: Signature was invalid"
+  );
+  t.end();
 });
 
 test("validation of first message (`seq` == 1) without `previous`", (t) => {
@@ -151,7 +146,7 @@ test("validation of first message (`seq` == 1) without `previous`", (t) => {
       toCallback((err, msgs) => {
         if (err) t.fail(err);
         // attempt validation of single message (assume `previous` is null)
-        t.true(validate.validateSingle(msgs[0]), "success");
+        t.equal(validate.validateSingle(msgs[0]), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -166,7 +161,7 @@ test("validation of a single message with `previous`", (t) => {
       toCallback((err, msgs) => {
         if (err) t.fail(err);
         // attempt validation of single message (include previous message)
-        t.true(validate.validateSingle(msgs[1], msgs[0]), "success");
+        t.equal(validate.validateSingle(msgs[1], msgs[0]), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -180,18 +175,13 @@ test("validation of a single message (`seq` > 1) without `previous`", (t) => {
       fromDB(db),
       toCallback((err, msgs) => {
         if (err) t.fail(err);
-        try {
-          // attempt validation of a single message without `previous`
-          validate.validateSingle(msgs[3]);
-          t.fail("should have thrown");
-        } catch (err) {
-          t.match(
-            err.message,
-            /The first message of a feed must have seq of 1/,
-            "found invalid message: The first message of a feed must have seq of 1"
-          );
-          t.end();
-        }
+        // attempt validation of a single message without `previous`
+        t.match(
+          validate.validateSingle(msgs[3]),
+          /The first message of a feed must have seq of 1/,
+          "found invalid message: The first message of a feed must have seq of 1"
+        );
+        t.end();
       })
     );
   });
@@ -204,7 +194,7 @@ test("batch validation of full feed", (t) => {
       toCallback((err, msgs) => {
         if (err) t.fail(err);
         // attempt validation of all messages (assume `previous` is null)
-        t.true(validate.validateBatch(msgs), "success");
+        t.equal(validate.validateBatch(msgs), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -221,7 +211,7 @@ test("batch validation of partial feed (previous seq == 1)", (t) => {
         // shift first msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages
-        t.true(validate.validateBatch(msgs, previous), "success");
+        t.equal(validate.validateBatch(msgs, previous), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -240,7 +230,7 @@ test("batch validation of partial feed (previous seq > 1)", (t) => {
         // shift second msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages
-        t.true(validate.validateBatch(msgs, previous), "success");
+        t.equal(validate.validateBatch(msgs, previous), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })
@@ -256,18 +246,13 @@ test("batch validation of partial feed without `previous`", (t) => {
         if (err) t.fail(err);
         // shift first msg into `previous`
         previous = msgs.shift();
-        try {
-          // attempt validation of all messages without `previous`
-          validate.validateBatch(msgs);
-          t.fail("should have thrown");
-        } catch (err) {
-          t.match(
-            err.message,
-            /The first message of a feed must have seq of 1/,
-            "found invalid message: The first message of a feed must have seq of 1"
-          );
-          t.end();
-        }
+        // attempt validation of all messages without `previous`
+        t.match(
+          validate.validateBatch(msgs),
+          /The first message of a feed must have seq of 1/,
+          "found invalid message: The first message of a feed must have seq of 1"
+        );
+        t.end();
       })
     );
   });
@@ -282,7 +267,7 @@ test("batch validation of out-of-order messages", (t) => {
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt validation of all messages
-        t.true(validate.validateOOOBatch(msgs), "success");
+        t.equal(validate.validateOOOBatch(msgs), null, "success");
         t.pass(`validated ${MESSAGES} messages`);
         t.end();
       })


### PR DESCRIPTION
Refactors verification and validation functions to return `null` on success and a `string` on error. This allows library users to break out of the `try catch` anti-pattern.

**Changes**

 - Return `Option<String>` instead of `Result<bool, NjError>` for all functions
 - Replace `throw` with `string` error return in `index.js` (wrapper code around Rust functions)
 - Update tests to reflect new return type
 - Update README

Tests are all passing. JS code has been linted. `clippy` is satisfied.